### PR TITLE
Use ` Union::Dll::Find` instead of Load

### DIFF
--- a/src/NonToxicUnfaker.cpp
+++ b/src/NonToxicUnfaker.cpp
@@ -8,7 +8,7 @@ struct Patch {
 };
 
 void ExecuteUnfaker() {
-    if (const Union::Dll *othelloAbi = Union::Dll::Load("OTHELLO_ABI.DLL")) {
+    if (const Union::Dll *othelloAbi = Union::Dll::Find("OTHELLO_ABI.DLL")) {
         void *imageBase;
         size_t imageLength;
         DWORD oldProtection;


### PR DESCRIPTION
Don't load dll if isn't loaded and don't increase reference counter of the plugin.